### PR TITLE
Make setup script portable to other Linux distros

### DIFF
--- a/dist/setup
+++ b/dist/setup
@@ -16,7 +16,7 @@ install_allegro() {
 		sudo apt-get install liballegro-acodec5.2
 		;;
 	debian|devuan)
-		sudo apt-get install liballegro5-dev
+		sudo apt-get install liballegro-acodec5.2
 		;;
 	*)
 		echo "You will need to install Allegro 5 manually (v5.2.7 or later is recommended)"

--- a/dist/setup
+++ b/dist/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 # XU4 Linux Installer
 
 install_allegro() {

--- a/dist/setup
+++ b/dist/setup
@@ -15,6 +15,9 @@ install_allegro() {
 		sudo add-apt-repository ppa:allegro/5.2
 		sudo apt-get install liballegro-acodec5.2
 		;;
+  debian|devuan)
+    sudo apt-get install liballegro5-dev
+    ;;
 	*)
 		echo "You will need to install Allegro 5 manually (v5.2.7 or later is recommended)"
 		;;

--- a/dist/setup
+++ b/dist/setup
@@ -15,9 +15,9 @@ install_allegro() {
 		sudo add-apt-repository ppa:allegro/5.2
 		sudo apt-get install liballegro-acodec5.2
 		;;
-  debian|devuan)
-    sudo apt-get install liballegro5-dev
-    ;;
+	debian|devuan)
+		sudo apt-get install liballegro5-dev
+		;;
 	*)
 		echo "You will need to install Allegro 5 manually (v5.2.7 or later is recommended)"
 		;;

--- a/dist/setup
+++ b/dist/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/usr/bin/env sh
 # XU4 Linux Installer
 
 install_allegro() {


### PR DESCRIPTION
When I originally went to run the setup-script that was included in the "Beta 5" release, I encountered an error due to the hashbang (in full disclosure, I am on a Devuan Chimaera system). I have adjusted this so that the script is more portable, on my machine and on others.

Any feedback is welcome.